### PR TITLE
Add force_folder_mode setting.

### DIFF
--- a/BetterSwitchHeaderImplementation.sublime-settings
+++ b/BetterSwitchHeaderImplementation.sublime-settings
@@ -1,4 +1,8 @@
 {
     // The maximal number of parent directories to traverse.
-    "sanity_limit": 3
+    "sanity_limit": 3,
+
+    // Force folder-mode, even if we've openend the project, e.g. if the
+    // project-file isn't at the root of the project.
+    "force_folder_mode": true,
 }

--- a/plugin.py
+++ b/plugin.py
@@ -49,7 +49,11 @@ class BetterSwitchHeaderImplementationCommand(sublime_plugin.WindowCommand):
 
         self.extensions = tuple(extensions)  # so we can use it with .endswith
 
-        if "project_path" in self.window.extract_variables():
+        force_folder_mode = sublime.load_settings(
+            "BetterSwitchHeaderImplementation.sublime-settings").get(
+                "force_folder_mode", False)
+        project_mode = "project_path" in self.window.extract_variables()
+        if project_mode and not force_folder_mode:
             # we're in a sublime project.
             self._project_mode()
         else:


### PR DESCRIPTION
If the project-file isn't located in the root of the project, this
settings allows you to force folder-mode instead.